### PR TITLE
Fixed a new line bug in http response

### DIFF
--- a/dbpedia/vsp/description.vsp
+++ b/dbpedia/vsp/description.vsp
@@ -206,7 +206,7 @@
 
   -- set up http
   -- http_header ('Cache-Control: no-cache, must-revalidate\r\nPragma: no-cache\r\n');
-  http_header (sprintf ('Expires: %s%s\r\n', date_rfc1123 (dateadd ('day', 7, now ())),links));
+  http_header (sprintf ('Expires: %s\r\n%s', date_rfc1123 (dateadd ('day', 7, now ())),links));
   --http(links);
 ?>
 


### PR DESCRIPTION
This patch fixes weird http response headers: Expires, Links and Content-Length.
